### PR TITLE
Implement ARMv8 NEON (AdvSIMD) acceleration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ license = "MIT"
 [dependencies]
 atty = "0.2"
 memmap = "0.7"
+
+[features]
+nightly = []

--- a/README.md
+++ b/README.md
@@ -41,9 +41,11 @@ cargo install tac
 
 Help is humbly requested in getting `tac` into the package managers for various platforms. It's really a time-consuming task, especially for someone that only interacts with the various packaging tools once in a blue moon as opposed to on a daily basis.
 
+Currently arm64 (aarch64) NEON acceleration is only available with the nightly compiler. If using it, provide the `--features nightly` flag to `cargo` to enable support.
+
 ## Implementation Notes
 
-This implementation of `tac` uses the AVX2 instruction set to provide SIMD acceleration for the detection of new lines. The usage of memory-mapped files additionally boosts performance by avoiding slowdowns caused by context switches when reading from the input if speculative execution mitigations are enabled. It is significantly (2.55x if mitigations disabled, more otherwise) faster than the version of `tac` that ships with GNU Coreutils, in addition to being more liberally licensed.
+This implementation of `tac` uses SIMD instruction sets (AVX2, NEON) to accelerate for the detection of new lines. The usage of memory-mapped files additionally boosts performance by avoiding slowdowns caused by context switches when reading from the input if speculative execution mitigations are enabled. It is significantly (2.55x if mitigations disabled, more otherwise) faster than the version of `tac` that ships with GNU Coreutils, in addition to being more liberally licensed.
 
 **To obtain maximum performance:**
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Currently arm64 (aarch64) NEON acceleration is only available with the nightly c
 
 ## Implementation Notes
 
-This implementation of `tac` uses SIMD instruction sets (AVX2, NEON) to accelerate for the detection of new lines. The usage of memory-mapped files additionally boosts performance by avoiding slowdowns caused by context switches when reading from the input if speculative execution mitigations are enabled. It is significantly (2.55x if mitigations disabled, more otherwise) faster than the version of `tac` that ships with GNU Coreutils, in addition to being more liberally licensed.
+This implementation of `tac` uses SIMD instruction sets (AVX2, NEON) to accelerate the detection of new lines. The usage of memory-mapped files additionally boosts performance by avoiding slowdowns caused by context switches when reading from the input if speculative execution mitigations are enabled. It is significantly (2.55x if mitigations disabled, more otherwise) faster than the version of `tac` that ships with GNU Coreutils, in addition to being more liberally licensed.
 
 **To obtain maximum performance:**
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,7 +240,7 @@ fn search128<W: Write>(bytes: &[u8], mut output: &mut W) -> Result<(), std::io::
                 let result128_3 = vceqq_u8(search128, pattern128);
 
                 // Bulk movemask as described in
-                // https://branchfree.org/2019/04/01/fitting-my-head-through-the-arm-holes-or-two-sequences-to-substitute-for-the-missing-pmovmskb-instruction-on-arm-neon/
+                // https://branchfree.org/2019/04/01/fitting-my-head-through-the-arm-holes/
                 let mut matches = {
                     let bit_mask: uint8x16_t = std::mem::transmute([
                         0x01u8, 0x02, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80, 0x01, 0x02, 0x4, 0x8, 0x10,


### PR DESCRIPTION
Before:

```
Benchmark #1: target/release/tac ~/big.log
  Time (mean ± σ):      1.721 s ±  0.012 s    [User: 1.418 s, System: 0.303 s]
  Range (min … max):    1.706 s …  1.738 s    10 runs
```

After:

```
Benchmark #1: target/release/tac ~/big.log
  Time (mean ± σ):     662.7 ms ±   7.8 ms    [User: 353.5 ms, System: 308.5 ms]
  Range (min … max):   650.1 ms … 673.0 ms    10 runs
```

:)